### PR TITLE
Add enhanced traverse char by char scoring system

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,6 +45,10 @@ func main() {
 		fmt.Fprint(os.Stderr, err)
 	}
 
+	if chain == nil {
+		return
+	}
+
 	fmt.Println("Best chain found:")
 	for _, word := range chain {
 		fmt.Println(word)

--- a/pkg/words/client.go
+++ b/pkg/words/client.go
@@ -92,6 +92,8 @@ func (c *Client) GetChain(start, end string) ([]string, error) {
 		return nil, fmt.Errorf("error, end word '%s' not found", end)
 	}
 
+	startWord.CalcScore(endWord.Term)
+
 	traverse := &Traverse{
 		StartWord: startWord,
 		EndWord:   endWord,

--- a/pkg/words/traverse.go
+++ b/pkg/words/traverse.go
@@ -86,7 +86,11 @@ func (t *Traverse) step(stepWord *Word, chain Chain) {
 			continue
 		}
 
-		t.step(stepWord.LinkedWords[i], chain)
+		stepWord.LinkedWords[i].CalcScore(t.EndWord.Term)
+
+		if stepWord.LinkedWords[i].Score > stepWord.Score {
+			t.step(stepWord.LinkedWords[i], chain)
+		}
 	}
 }
 

--- a/pkg/words/traverse_test.go
+++ b/pkg/words/traverse_test.go
@@ -17,6 +17,7 @@ func TestPerform(t *testing.T) {
 				},
 			},
 		},
+		Score: 1,
 	}
 
 	tests := []struct {

--- a/pkg/words/word.go
+++ b/pkg/words/word.go
@@ -4,6 +4,7 @@ package words
 type Word struct {
 	Term        string
 	LinkedWords []*Word
+	Score       int
 }
 
 // Link would seek linked words for the given word on a word's dictionary.
@@ -16,6 +17,32 @@ func (w *Word) Link(words []*Word) {
 	for i := 0; i < len(words); i++ {
 		if w.isLinkable(*words[i]) {
 			w.LinkedWords = append(w.LinkedWords, words[i])
+		}
+	}
+}
+
+// CalcScore method will calculate a score for the given word based on the
+// same chars at the same position compared with a target word.
+//
+// target: The give word as string to compare to
+//
+// Ex:
+// Given foo & feo
+// f o o
+// 1 0 1 = 2 Score
+// f e o
+//
+// Given foo & bar
+// f o o
+// 0 0 0 = 0 Score
+// b a r
+//
+// Returns nothing.
+func (w *Word) CalcScore(target string) {
+	w.Score = 0
+	for i := 0; i < len(w.Term); i++ {
+		if w.Term[i] == target[i] {
+			w.Score += 1
 		}
 	}
 }

--- a/pkg/words/word_test.go
+++ b/pkg/words/word_test.go
@@ -44,3 +44,37 @@ func TestLink(t *testing.T) {
 		})
 	}
 }
+
+func TestCalcScore(t *testing.T) {
+	tests := []struct {
+		Description   string
+		Word          Word
+		EndWord       string
+		ExpectedScore int
+	}{
+		{
+			Description:   "when CalcScore succesfully calculates an score for two words",
+			Word:          Word{Term: "foo"},
+			EndWord:       "feo",
+			ExpectedScore: 2,
+		},
+		{
+			Description:   "when CalcScore succesfully calculates an score for two words",
+			Word:          Word{Term: "foo"},
+			EndWord:       "bar",
+			ExpectedScore: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Description, func(t *testing.T) {
+			test.Word.CalcScore(test.EndWord)
+
+			if !reflect.DeepEqual(test.Word.Score, test.ExpectedScore) {
+				t.Fatalf("expected ExpectedScore to be %v, got %v",
+					test.ExpectedScore,
+					test.Word.Score)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a scoring system, that will enhance the traverse search just by moving into chains that have higher score given the following scoring system:

I've created a CalcScore method that will calculate a score for the given word based on the same chars at the same position compared with a target word.

```
Ex:
Given foo & feo
f o o
1 0 1 = 2 Score
f e o

Given foo & bar
f o o
0 0 0 = 0 Score
b a r
```

